### PR TITLE
Behavior のキャンセル対応

### DIFF
--- a/.azuredevops/azure-pipelines.yml
+++ b/.azuredevops/azure-pipelines.yml
@@ -42,6 +42,6 @@ steps:
   displayName: 'NuGet Authenticate'
 
 - script: |
-    dotnet nuget push --source "https://pkgs.dev.azure.com/archwaydev/5793cbd9-a472-4a2d-8955-d865d42a2d11/_packaging/Archway-SharedLib/nuget/v3/index.json" --api-key az $(Build.ArtifactStagingDirectory)/*.nupkg
+    dotnet nuget push --skip-duplicate --source "https://pkgs.dev.azure.com/archwaydev/5793cbd9-a472-4a2d-8955-d865d42a2d11/_packaging/Archway-SharedLib/nuget/v3/index.json" --api-key az $(Build.ArtifactStagingDirectory)/*.nupkg
   displayName: Push
 

--- a/src/Nut.MediatR.Behaviors.FluentValidation/FluentValidationBehavior.cs
+++ b/src/Nut.MediatR.Behaviors.FluentValidation/FluentValidationBehavior.cs
@@ -40,7 +40,7 @@ public class FluentValidationBehavior<TRequest, TResponse> : IPipelineBehavior<T
             var failures = validationResults.SelectMany(r => r.Errors).Where(f => f is not null).ToList();
             if (failures.Any()) throw new ValidationException(failures);
         }
-        return await next().ConfigureAwait(false);
+        return await next(cancellationToken).ConfigureAwait(false);
     }
 }
 

--- a/src/Nut.MediatR.Behaviors/Authorization/AuthorizationBehavior.cs
+++ b/src/Nut.MediatR.Behaviors/Authorization/AuthorizationBehavior.cs
@@ -51,7 +51,7 @@ public class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
             }
         }
 
-        return await next().ConfigureAwait(false);
+        return await next(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Nut.MediatR.Behaviors/Logging/LoggingBehavior.cs
+++ b/src/Nut.MediatR.Behaviors/Logging/LoggingBehavior.cs
@@ -53,7 +53,7 @@ public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, 
         var logger = ServiceProvider.GetFirstServiceOrDefault<ILogger<LoggingBehavior<TRequest, TResponse>>>();
         if (logger is null)
         {
-            return await next().ConfigureAwait(false);
+            return await next(cancellationToken).ConfigureAwait(false);
         }
 
         var collector = GetCollector() ?? GetDefaultCollector();

--- a/src/Nut.MediatR.Behaviors/RequestAware/RequestAwareBehavior.cs
+++ b/src/Nut.MediatR.Behaviors/RequestAware/RequestAwareBehavior.cs
@@ -41,7 +41,7 @@ public class RequestAwareBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
 
     private async Task<TResponse> ExecuteBehaviors(IList<Type> types, TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
-        if (!types.Any()) return await next.Invoke().ConfigureAwait(false);
+        if (!types.Any()) return await next.Invoke(cancellationToken).ConfigureAwait(false);
         var type = types[0];
         types.RemoveAt(0);
         if (_provider.GetService(type) is not IPipelineBehavior<TRequest, TResponse> service)

--- a/src/Nut.MediatR.Behaviors/Validation/DataAnnotationValidationBehavior.cs
+++ b/src/Nut.MediatR.Behaviors/Validation/DataAnnotationValidationBehavior.cs
@@ -29,6 +29,6 @@ public class DataAnnotationValidationBehavior<TRequest, TResponse> : IPipelineBe
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         Validator.ValidateObject(request, new ValidationContext(request), true);
-        return await next().ConfigureAwait(false);
+        return await next(cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
This pull request includes updates to improve the handling of `CancellationToken` in multiple pipeline behaviors and enhances the NuGet push script to handle duplicate package uploads more gracefully. Below is a summary of the most important changes:

### Improvements to `CancellationToken` Handling:

* Updated the `Handle` method in `FluentValidationBehavior` to pass the `cancellationToken` when invoking the next delegate in the pipeline. (`src/Nut.MediatR.Behaviors.FluentValidation/FluentValidationBehavior.cs`)
* Updated the `Handle` method in `AuthorizationBehavior` to include the `cancellationToken` when calling the next delegate. (`src/Nut.MediatR.Behaviors/Authorization/AuthorizationBehavior.cs`)
* Modified the `Handle` method in `LoggingBehavior` to propagate the `cancellationToken` to the next delegate. (`src/Nut.MediatR.Behaviors/Logging/LoggingBehavior.cs`)
* Adjusted the `ExecuteBehaviors` method in `RequestAwareBehavior` to pass the `cancellationToken` when invoking the next delegate. (`src/Nut.MediatR.Behaviors/RequestAware/RequestAwareBehavior.cs`)
* Updated the `Handle` method in `DataAnnotationValidationBehavior` to ensure the `cancellationToken` is passed to the next delegate. (`src/Nut.MediatR.Behaviors/Validation/DataAnnotationValidationBehavior.cs`)

### Enhancements to NuGet Push Script:

* Added the `--skip-duplicate` flag to the NuGet push script in the Azure DevOps pipeline configuration to avoid errors when attempting to push duplicate packages. (`.azuredevops/azure-pipelines.yml`)

azure-pipelines.ymlファイルで、`dotnet nuget push`コマンドに`--skip-duplicate`オプションを追加し、重複するパッケージのプッシュをスキップできるようにしました。

FluentValidationBehavior.cs、AuthorizationBehavior.cs、LoggingBehavior.cs、RequestAwareBehavior.cs、DataAnnotationValidationBehavior.csの各ファイルでは、`next()`メソッドの呼び出しに`cancellationToken`引数を追加し、非同期処理のキャンセルが可能になりました。